### PR TITLE
Custom escape functions support

### DIFF
--- a/mustache.hpp
+++ b/mustache.hpp
@@ -52,7 +52,7 @@ string_type trim(const string_type& s) {
 }
 
 template <typename string_type>
-string_type escape(const string_type& s) {
+string_type html_escape(const string_type& s) {
     string_type ret;
     ret.reserve(s.size()*2);
     for (const auto ch : s) {
@@ -362,6 +362,15 @@ public:
     
     const string_type& error_message() const {
         return errorMessage_;
+    }
+
+    bool is_custom_escape() const {
+        return bool(escapeFn_);
+    }
+
+    template <typename FnType>
+    void set_custom_escape(FnType escape_fn) {
+        escapeFn_ = escape_fn;
     }
 
     template <typename StreamType>
@@ -860,9 +869,14 @@ private:
         }
     }
 
+    string_type escape(const string_type& s) const {
+        return escapeFn_ ? escapeFn_(s) : html_escape(s);
+    }
+
 private:
     string_type errorMessage_;
     Component rootComponent_;
+    std::function<string_type(const string_type&)> escapeFn_;
 };
 
 using mustache = basic_mustache<std::string>;

--- a/tests.cpp
+++ b/tests.cpp
@@ -113,7 +113,27 @@ TEST_CASE("variables") {
         data.set("name", "\"S\"<br>te&v\'e");
         CHECK(tmpl.render(data) == "Hello \"S\"<br>te&v\'e");
     }
-    
+
+    SECTION("custom_escaped") {
+        mustache tmpl("printf(\"Say {{password}} and enter\");{{&newline}}");
+        tmpl.set_custom_escape([](const std::string& s) -> std::string {
+            std::string ret; ret.reserve(s.size());
+            for (const auto ch: s) {
+                switch (ch) {
+                    case '\"':
+                    case '\n':
+                        ret.append({'\\', ch});
+                        break;
+                    default:
+                        ret.append(1, ch);
+                }
+            }
+            return ret;
+        });
+        object data{ { "password", "\"friend\"" }, { "newline", "\n" } };
+        CHECK(tmpl.render(data) == "printf(\"Say \\\"friend\\\" and enter\");\n");
+    }
+
     SECTION("empty_name") {
         mustache tmpl("Hello {{}}");
         data data;


### PR DESCRIPTION
Mustache can be used for things other than HTML - for example, it can be used to escape strings in C/C++ code (as the limited test illustrates). Somewhat similar to what's been done in https://github.com/no1msd/mstch, `basic_mustache` is made configurable to call either a custom escape function or the default HTML escape function if there's no custom one.