### PR TITLE
Carry over custom escape function into lambda rendered fragments

### DIFF
--- a/mustache.hpp
+++ b/mustache.hpp
@@ -827,9 +827,11 @@ private:
             };
             if (parseWithSameContext) {
                 basic_mustache tmpl{text, ctx};
+                tmpl.set_custom_escape(escape_);
                 return processTemplate(tmpl);
             }
             basic_mustache tmpl{text};
+            tmpl.set_custom_escape(escape_);
             return processTemplate(tmpl);
         };
         if (var->is_lambda2()) {

--- a/tests.cpp
+++ b/tests.cpp
@@ -962,6 +962,29 @@ TEST_CASE("custom_escape") {
         CHECK(tmpl.render(dat) == "hello \\\"friend\\\"");
     }
 
+    SECTION("#lambda") {
+        mustache tmpl{"hello {{#quote}}friend{{/quote}}"};
+        data dat("quote", data{lambda{[](const std::string& s){
+            return '"' + s + '"';
+        }}});
+        tmpl.set_custom_escape([](const std::string& s) {
+            std::string ret; ret.reserve(s.size());
+            for (const auto ch: s) {
+                switch (ch) {
+                    case '\"':
+                    case '\n':
+                        ret.append({'\\', ch});
+                        break;
+                    default:
+                        ret.append(1, ch);
+                        break;
+                }
+            }
+            return ret;
+        });
+        CHECK(tmpl.render(dat) == "hello \\\"friend\\\"");
+    }
+
     SECTION("partial") {
         mustache tmpl{"hello {{>partial}}"};
         object dat({{"what", "\"friend\""}, {"partial", data{partial{[](){

--- a/tests.cpp
+++ b/tests.cpp
@@ -965,7 +965,7 @@ TEST_CASE("custom_escape") {
     SECTION("#lambda") {
         mustache tmpl{"hello {{#quote}}friend{{/quote}}"};
         data dat("quote", data{lambda{[](const std::string& s){
-            return '"' + s + '"';
+            return "<\"" + s + "\">";
         }}});
         tmpl.set_custom_escape([](const std::string& s) {
             std::string ret; ret.reserve(s.size());


### PR DESCRIPTION
Two more (and, it seems, the last) places where escape_ should be carried over to a locally created `basic_mustache` object.