### PR TITLE
Add an overload to render() that accepts a context and a stream

### DIFF
--- a/mustache.hpp
+++ b/mustache.hpp
@@ -885,7 +885,7 @@ public:
     }
 
     template <typename stream_type>
-    stream_type render(basic_context<string_type>& ctx, stream_type& stream) {
+    stream_type& render(basic_context<string_type>& ctx, stream_type& stream) {
         context_internal<string_type> context{ctx};
         render([&stream](const string_type& str) {
             stream << str;
@@ -893,7 +893,7 @@ public:
         return stream;
     }
 
-    string_type render(const basic_context<string_type>& ctx) {
+    string_type render(basic_context<string_type>& ctx) {
         std::basic_ostringstream<typename string_type::value_type> ss;
         return render(ctx, ss).str();
     }

--- a/mustache.hpp
+++ b/mustache.hpp
@@ -884,13 +884,18 @@ public:
         return render(data, ss).str();
     }
 
-    string_type render(basic_context<string_type>& ctx) {
-        std::basic_ostringstream<typename string_type::value_type> ss;
+    template <typename stream_type>
+    stream_type render(basic_context<string_type>& ctx, stream_type& stream) {
         context_internal<string_type> context{ctx};
-        render([&ss](const string_type& str) {
-            ss << str;
+        render([&stream](const string_type& str) {
+            stream << str;
         }, context);
-        return ss.str();
+        return stream;
+    }
+
+    string_type render(const basic_context<string_type>& ctx) {
+        std::basic_ostringstream<typename string_type::value_type> ss;
+        return render(ctx, ss).str();
     }
 
     using render_handler = std::function<void(const string_type&)>;

--- a/tests.cpp
+++ b/tests.cpp
@@ -1135,6 +1135,9 @@ TEST_CASE("custom_context") {
     SECTION("basic") {
         my_context<mustache::string_type> ctx;
         mustache tmpl("Hello {{what}}");
+        std::ostream& stream = tmpl.render(ctx, std::cout) << std::endl;
+        CHECK(tmpl.is_valid());
+        CHECK(tmpl.error_message() == "");
         CHECK(tmpl.render(ctx) == "Hello Steve");
     }
 


### PR DESCRIPTION
There's a two-argument `render()` overload for `basic_data<>`, making one for `basic_context<>` in the same way is pretty obvious.