### PR TITLE
Fix compiling of tests on gcc8.2

### DIFF
--- a/tests.cpp
+++ b/tests.cpp
@@ -1091,7 +1091,7 @@ TEST_CASE("custom_escape") {
         mustache::escape_handler esc;
         tmpl.set_custom_escape(esc);
         object dat({ {"what", "\"friend\""} });
-        CHECK_THROWS_AS(tmpl.render(dat), std::bad_function_call);
+        CHECK_THROWS_AS(tmpl.render(dat), std::bad_function_call&);
     }
 
 }


### PR DESCRIPTION
```
In file included from tests.cpp:32:
tests.cpp: In function 'void ____C_A_T_C_H____T_E_S_T____114()':
tests.cpp:1094:48: error: catching polymorphic type 'class std::bad_function_call' by value [-Werror=catch-value=]
         CHECK_THROWS_AS(tmpl.render(dat), std::bad_function_call);
                                                ^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as error
```