### PR TITLE
Add virtual default destructor to basic_context.

### DIFF
--- a/mustache.hpp
+++ b/mustache.hpp
@@ -425,6 +425,7 @@ const string_type delimiter_set<string_type>::default_end(2, '}');
 template <typename string_type>
 class basic_context {
 public:
+    virtual ~basic_context() = default;
     virtual void push(const basic_data<string_type>* data) = 0;
     virtual void pop() = 0;
 


### PR DESCRIPTION
Compilation fails with `-Wnon-virtual-dtor -Werror` because
`basic_context` has virtual methods but no virtual destructor.

This add a virtual destructor, using the default implementation.