### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,19 @@ matrix:
 
     - os: osx
       compiler: clang
+      
+    - os: linux
+      arch: ppc64le
+      compiler: gcc
+
+    - os: linux
+      arch: ppc64le
+      compiler: clang
+
+    - os: osx
+      arch: ppc64le
+      compiler: clang
+      
 
 script:
   - cd tests && make coverage


### PR DESCRIPTION

Hi,
I had added ppc64le(Linux on Power) support on travis-ci and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/Mustache/builds/198817157

Please have a look.

Regards,
Manish Kumar