### PR TITLE
Don't assign -1 to unsigned types

### DIFF
--- a/mustache.hpp
+++ b/mustache.hpp
@@ -660,7 +660,7 @@ private:
         std::vector<component<string_type>*> sections{&root_component};
         std::vector<string_size_type> section_starts;
         string_type current_text;
-        string_size_type current_text_position = -1;
+        string_size_type current_text_position = string_type::npos;
 
         current_text.reserve(input_size);
 
@@ -669,7 +669,7 @@ private:
                 const component<string_type> comp{current_text, current_text_position};
                 sections.back()->children.push_back(comp);
                 current_text.clear();
-                current_text_position = -1;
+                current_text_position = string_type::npos;
             }
         };
 


### PR DESCRIPTION
`std::string::size_type` is unsigned and can't hold negative numbers, `std::string::npos` seems like a better choice here