### PR TITLE
Fix cmake_minimum_required to be compatible with modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.0.2...3.10)
 project(mustache)
 add_library(mustache INTERFACE)
 


### PR DESCRIPTION
Due to CMake 4.0 drop deprications to 3.5  
I choose 3.10 because it have some other of deprications  